### PR TITLE
컴포넌트 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import NoiseMap from './page/noiseMap/NoiseMap'
 import DeleteModal from './component/deleteModal/DeleteModal'
 import { toggleDeleteModal } from './store/menu/menuSlice' // 액션 가져오기
 
+
 function AppContent() {
   const location = useLocation();
   const dispatch = useAppDispatch(); // dispatch를 사용하기 위한 훅

--- a/src/component/currentLocate/AddressDisplay.styles.ts
+++ b/src/component/currentLocate/AddressDisplay.styles.ts
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const LocateWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    max-width: 8.625rem;
+    height: 1.5rem;
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
+    font-family: 'Pretendard';
+    font-weight: 500;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    color: #6D6D6D;
+`
+
+export const LocateIcoWrapper = styled.div`
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.1875rem;
+    img {
+        width: 100%;
+        height: 100%;
+    }
+`

--- a/src/component/currentLocate/AddressDisplay.tsx
+++ b/src/component/currentLocate/AddressDisplay.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import LocateIco from '../../assets/icons/ico_locate@2x.png'
+import { LocateIcoWrapper, LocateWrapper } from './AddressDisplay.styles';
 
 interface AddressDisplayProps {
   address: string | null;
@@ -8,18 +10,25 @@ interface AddressDisplayProps {
 
 const AddressDisplay: React.FC<AddressDisplayProps> = ({ address, locationError, addressError }) => {
   if (locationError) {
-    return <div>현재 위치를 가져올 수 없습니다: {locationError}</div>;
+    return <LocateWrapper>현재 위치를 가져올 수 없습니다: {locationError}</LocateWrapper>;
   }
 
   if (addressError) {
-    return <div>주소 변환 오류: {addressError}</div>;
+    return <LocateWrapper>주소 변환 오류: {addressError}</LocateWrapper>;
   }
 
   if (address) {
-    return <div>현재 위치: {address}</div>;
+    return (
+      <LocateWrapper>
+        <LocateIcoWrapper>
+          <img src={LocateIco} alt='위치_아이콘'/>
+        </LocateIcoWrapper> 
+        <p>{address}</p>
+      </LocateWrapper>
+    );
   }
 
-  return <div>위치를 불러오는 중...</div>;
+  return <LocateWrapper>위치를 불러오는 중...</LocateWrapper>;
 };
 
 export default AddressDisplay;

--- a/src/component/decibelChart/DecibelChart.styles.ts
+++ b/src/component/decibelChart/DecibelChart.styles.ts
@@ -1,115 +1,53 @@
 import styled from "styled-components";
 
-export const Header = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 24px;
-    margin: 31px 18px 32px 18px;
-    div {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-`
-
-
-export const ChartWrapper = styled.div`
-    width: 340px;
-    height: 444px;
-    border: 2px solid #D7D7D7;
-    border-radius: 16px;
-    background-color: #f4f4f4;
-    display: flex;
-    flex-direction: column;
-    padding: 12px 16px 13px 16px;
-    margin: 0 12px 13px;
-`
-
-export const DateAndPositionContainer = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-family: 'Pretendard';
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 24px;
-    color: #6d6d6d;
-`
-
-export const PositionWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-`
-
-export const DateWrapper = styled.div`
-    width: 123px;
-    height: 53px;
-    display: flex;
-    align-items: center;
-`
-
-export const MarkerWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-`
-
-
 export const DecibelContainer = styled.div`
-    width: 100%;
-    height: 92px;
+    width: 19.25rem;
+    height: 3rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: nowrap;
     font-weight: 500;
-    font-size: 16px;
-    line-height: 24px;
+    font-size: 1rem;
+    line-height: 1.5rem;
     color: #6d6d6d;
-    margin-bottom: 28px;
+    margin-bottom: 1.75rem;
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
+    letter-spacing: -0.02125rem;
 `
 
 export const AverageDecibelWrapper = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: flex-end;
-    p {
-        text-align: center;
-    }
+    align-items: flex-start;
+    justify-content: center;
 `
 
 export const CurrentDecibelWrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: space-between;
     p {
         text-align: center;
         font-weight: 600;
-    };
-    p:first-child {
-        font-size: 20px;
-        line-height: 20px;
         color: #007BFF;
     };
+    p:first-child {
+        font-size: 1.25rem;
+        line-height: 1.25rem;
+    };
     p:last-child {
-        font-size: 16px;
-        line-height: 24px;
-        color: #007BFF
+        font-size: 1rem;
+        line-height: 1.5rem;
     }
 `
 
 export const MaxDecibelWrapper = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: flex-end;
-    p {
-        text-align: center;
-    }
+    align-items: flex-end;
+    justify-content: center;
 `
 
 export const ChartBtn = styled.button`

--- a/src/component/decibelChart/DecibelChart.tsx
+++ b/src/component/decibelChart/DecibelChart.tsx
@@ -1,100 +1,25 @@
-import React, { useEffect, useState } from 'react';
-import useRecordWithDecibel from '../../hook/useRecordWithDecibel';
+import React from 'react';
 import { Line } from 'react-chartjs-2';
 import { Chart, registerables } from 'chart.js';
-import { AverageDecibelWrapper, CancelBtn, ChartBtn, ChartContainer, ChartWrapper, CurrentDecibelWrapper, DateAndPositionContainer, DateWrapper, DecibelContainer, Header, InfoWrapper, MarkerWrapper, MaxDecibelWrapper, PositionWrapper, SaveBtn } from './DecibelChart.styles';
-import { NavLink } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { setDecibel } from '../../store/data/dataSlice';
+import { AverageDecibelWrapper, CurrentDecibelWrapper, DecibelContainer, MaxDecibelWrapper } from './DecibelChart.styles';
+import { DecibelDataPoint } from '../../types/DecibelDataPoint';
+import { useAppSelector } from '../../hook/redux';
+import { RootState } from '../../store';
 
 Chart.register(...registerables);
 
-interface DecibelDataPoint {
-    x: string;
-    y: number;
-}
-
 interface DecibelMeterProps {
-    address: string; // address를 props로 받음
+    decibel: number,
+    dataPoints: DecibelDataPoint[],
+    averageDecibel: number,
+    maxDecibel: number
 }
 
-const DecibelMeter: React.FC<DecibelMeterProps> = () => {
-    // const { startMeasuringDecibel, stopMeasuringDecibel, decibel } = useRecordWithDecibel();
-    const [isRecording, setIsRecording] = useState(false);
-    const [dataPoints, setDataPoints] = useState<DecibelDataPoint[]>([]); // Change to store time and decibel
-    const [averageDecibel, setAverageDecibel] = useState<number>(0);
-    const [maxDecibel, setMaxDecibel] = useState<number>(0); 
-    const [currentTime, setCurrentTime] = useState<string>("");
-    const [fixedTime, setFixedTime] = useState<string | null>(null);
-    const [isTimeFixed, setIsTimeFixed] = useState<boolean>(false); // 시간이 고정되었는지 여부
+const DecibelChart: React.FC<DecibelMeterProps> = ({
+  decibel, dataPoints, averageDecibel, maxDecibel
+}) => {
 
-
-    const dispatch = useDispatch();
-
-    // 실시간 시간을 업데이트하는 useEffect
-    useEffect(() => {
-      if (isTimeFixed) return; // 시간이 고정된 경우 업데이트 멈춤
-  
-      const updateTime = () => {
-        const now = new Date();
-        const formattedTime = formatDateTime(now); // 초를 포함한 시간 형식
-        setCurrentTime(formattedTime);
-      };
-  
-      updateTime(); // 초기 시간 설정
-      const interval = setInterval(updateTime, 1000); // 1초마다 업데이트
-  
-      return () => clearInterval(interval); // 컴포넌트 언마운트 시 클리어
-    }, [isTimeFixed]); // isTimeFixed가 바뀔 때마다 실행
-  
-    // 버튼 클릭 시 고정 시간 설정
-    const handleButtonClick = () => {
-      if (!isTimeFixed) {
-        setFixedTime(currentTime); // 현재 시간을 고정
-        setIsTimeFixed(true); // 시간이 고정되었음을 표시
-      }
-    };
-  
-    // 시간 포맷 함수 (초 추가)
-    const formatDateTime = (date: Date): string => {
-        const year = date.getFullYear();
-        const month = String(date.getMonth() + 1).padStart(2, "0");
-        const day = String(date.getDate()).padStart(2, "0");
-        const hours = String(date.getHours()).padStart(2, "0");
-        const minutes = String(date.getMinutes()).padStart(2, "0");
-        return `${year}.${month}.${day} ${hours}:${minutes}`;  // 초 포함
-    };
-
-  const handleToggleRecording = () => {
-    if (isRecording) {
-      stopMeasuringDecibel();
-      handleButtonClick(); // recording 중지 시에도 시간 고정 버튼 클릭
-    } else {
-      startMeasuringDecibel();
-      handleButtonClick(); // recording 시작 시 시간 고정
-    }
-    setIsRecording(!isRecording);
-  };
-    // Update chart data with timestamp
-    useEffect(() => {
-        if (isRecording) {
-            const timestamp = new Date().toISOString();
-            const currentDecibel = decibel === -Infinity ? 0 : decibel; // Set 0 if decibel is -Infinity
-            setDataPoints((prev) => [...prev.slice(-49), { x: timestamp, y: currentDecibel }]); // Keep last 50 data points
-            if (currentDecibel > maxDecibel) {
-                setMaxDecibel(currentDecibel);
-            }
-        }
-    }, [decibel, isRecording]);
-
-    // Average decibel calculation (optional, if you want to track the average)
-    useEffect(() => {
-        if (dataPoints.length > 0) {
-            const totalDecibels = dataPoints.reduce((sum, point) => sum + point.y, 0);
-            const average = totalDecibels / dataPoints.length;
-            setAverageDecibel(average);
-        }
-    }, [dataPoints]);
+    const { isRecording } = useAppSelector((state: RootState) => state.dateTime);
 
     // Chart.js data and options
     const chartData = {
@@ -144,76 +69,29 @@ const DecibelMeter: React.FC<DecibelMeterProps> = () => {
     
 
   return (
-    // <ChartContainer>
-    //     {/* <Header>
-    //         <div>
-    //             <img src={Logo} alt='logo' />
-    //         </div>
-    //         <div onClick={() => dispatch(toggleModal(true))}>
-    //             <img src={Info} alt='info' />
-    //         </div>            
-    //     </Header> */}
-    //     <ChartWrapper>
-    //         <DateAndPositionContainer>
-    //             <DateWrapper>
-    //                 {fixedTime ? `${fixedTime}` : `${currentTime}`}
-    //             </DateWrapper>
-    //             <PositionWrapper>
-    //                 <img src={LocateIcon} alt='positionMarker' />
-    //                 {address}
-    //             </PositionWrapper>
-    //         </DateAndPositionContainer>
-    //         <MarkerWrapper>
-    //             { isRecording && averageDecibel < 70 ? <img src={MarkerGreen} alt='marker' /> 
-    //                 : isRecording && averageDecibel < 100 ? <img src={MarkerBlue} alt='marker' /> 
-    //                     : isRecording && averageDecibel < 120 ? <img src={MarkerRed} alt='marker'/> 
-    //                         : <img src={MarkerDefault} alt='marker' /> }
-    //         </MarkerWrapper>
-    //         <DecibelContainer>
-    //             <AverageDecibelWrapper>
-    //                 <p>평균</p>
-    //                 <p>{averageDecibel.toFixed(0)}</p>
-    //             </AverageDecibelWrapper>
-    //             <CurrentDecibelWrapper>
-    //                 <p>
-    //                 { isRecording && averageDecibel < 70 ? "조용함" 
-    //                 : isRecording && averageDecibel < 100 ? "보통" 
-    //                     : isRecording && averageDecibel < 120 ? "시끄러움" 
-    //                         : "측정 전" }  
-    //                 </p>
-    //                 <p>현재 {decibel.toFixed(0)}dB</p>
-    //             </CurrentDecibelWrapper>
-    //             <MaxDecibelWrapper>
-    //                 <p>최대</p>
-    //                 <p>{maxDecibel.toFixed(0)}</p>
-    //             </MaxDecibelWrapper>
-    //         </DecibelContainer>
-        //     <Line data={chartData} options={options} style={{ width: '100%', height: '172px' }}  />
-        //     <InfoWrapper>
-        //         <p>소음 측정을 시작할 준비가 됐어요</p>
-        //         <p>잠시만 기다려주세요. 평균값을 계산 중입니다.</p>
-        //     </InfoWrapper>
-        // // </ChartWrapper>
-        // {isRecording ? (
-        //         <>
-        //             <NavLink to='/register'>
-        //                 <SaveBtn onClick={()=>{dispatch(setDecibel({maxdB: maxDecibel.toFixed(0), averagedB: averageDecibel.toFixed(0), date: fixedTime }))}}>
-        //                     측정 저장
-        //                 </SaveBtn>
-        //             </NavLink>
-        //             <CancelBtn onClick={handleToggleRecording}>
-        //                 취소
-        //             </CancelBtn>
-        //         </>
-        //     ) : (
-        //         <ChartBtn onClick={handleToggleRecording}>
-        //             측정 시작
-        //         </ChartBtn>
-        //     )
-        // }
-    // </ChartContainer>
-    <div></div>
+    <>
+      <DecibelContainer>
+          <AverageDecibelWrapper>
+              <p>평균</p>
+              <p>{averageDecibel.toFixed(0)}</p>
+          </AverageDecibelWrapper>
+          <CurrentDecibelWrapper>
+              <p>
+              { isRecording && averageDecibel < 70 ? "조용함" 
+              : isRecording && averageDecibel < 100 ? "보통" 
+                  : isRecording && averageDecibel < 120 ? "시끄러움" 
+                      : "측정 전" }  
+              </p>
+              <p>현재 {decibel.toFixed(0)}dB</p>
+          </CurrentDecibelWrapper>
+          <MaxDecibelWrapper>
+              <p>최대</p>
+              <p>{maxDecibel.toFixed(0)}</p>
+          </MaxDecibelWrapper>
+      </DecibelContainer>
+      <Line data={chartData} options={options} style={{ width: '19.75rem', height: '10.75rem', marginBottom: '1.625rem' }}  />
+    </>
   );
 };
 
-export default DecibelMeter;
+export default DecibelChart;

--- a/src/component/decibelChart/DecibelChart.tsx
+++ b/src/component/decibelChart/DecibelChart.tsx
@@ -3,15 +3,9 @@ import useRecordWithDecibel from '../../hook/useRecordWithDecibel';
 import { Line } from 'react-chartjs-2';
 import { Chart, registerables } from 'chart.js';
 import { AverageDecibelWrapper, CancelBtn, ChartBtn, ChartContainer, ChartWrapper, CurrentDecibelWrapper, DateAndPositionContainer, DateWrapper, DecibelContainer, Header, InfoWrapper, MarkerWrapper, MaxDecibelWrapper, PositionWrapper, SaveBtn } from './DecibelChart.styles';
-import MarkerDefault from '../../assets/icons/ico_marker_default.png';
-import MarkerGreen from '../../assets/icons/ico_marker_green.png';
-import MarkerBlue from '../../assets/icons/ico_marker_blue.png';
-import MarkerRed from '../../assets/icons/ico_marker_red.png';
-import LocateIcon from '../../assets/icons/ico_locate.png';
 import { NavLink } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setDecibel } from '../../store/data/dataSlice';
-// import { toggleModal } from '../../store/menu/menuSlice';
 
 Chart.register(...registerables);
 

--- a/src/component/marker/Marker.style.ts
+++ b/src/component/marker/Marker.style.ts
@@ -1,12 +1,14 @@
 import styled from "styled-components";
 
 export const MarkerWrapper = styled.div`
-    width: 100%;
+    width: 19.25rem;
     min-height: 2rem;
     display: flex;
     align-items: center;
     justify-content: center;
     margin-bottom: 0.75rem;
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
     img {
         width: 2rem;
         height: 2rem;

--- a/src/component/marker/Marker.style.ts
+++ b/src/component/marker/Marker.style.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const MarkerWrapper = styled.div`
+    width: 100%;
+    min-height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 0.75rem;
+    img {
+        width: 2rem;
+        height: 2rem;
+    }
+`

--- a/src/component/marker/Marker.tsx
+++ b/src/component/marker/Marker.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import MarkerDefault from '../../assets/icons/ico_marker_default.png';
+import MarkerGreen from '../../assets/icons/ico_marker_green.png';
+import MarkerBlue from '../../assets/icons/ico_marker_blue.png';
+import MarkerRed from '../../assets/icons/ico_marker_red.png';
+import { MarkerWrapper } from './Marker.style';
+
+interface MarkerProps {
+  averageDecibel: number; // 평균 데시벨
+  isRecording: boolean;   // 측정 중인지 여부
+}
+
+const Marker: React.FC<MarkerProps> = ({ averageDecibel, isRecording }) => {
+  let markerSrc = MarkerDefault; // 기본 마커
+  
+  if (isRecording) {
+    if (averageDecibel < 70) {
+      markerSrc = MarkerGreen;
+    } else if (averageDecibel < 100) {
+      markerSrc = MarkerBlue;
+    } else if (averageDecibel <= 120) {
+      markerSrc = MarkerRed;
+    }
+  }
+
+  return (
+        <MarkerWrapper>
+            <img src={markerSrc} alt="marker" />
+        </MarkerWrapper>
+    );
+};
+
+export default Marker;

--- a/src/component/measureBtn/MeasureBtn.styles.ts
+++ b/src/component/measureBtn/MeasureBtn.styles.ts
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+
+export const StartBtn = styled.button`
+    width: 21.25rem;
+    height: 3.125rem;
+    background-color: #007BFF;
+    color: white;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.25rem;
+    padding: 0.9375rem 7.5625rem;
+    border: none;
+    border-radius: 3.625rem;
+    gap: 0.625rem;
+    cursor: pointer;
+`
+
+export const CancelBtn = styled.button`
+    width: 21.25rem;
+    height: 3.125rem;
+    background-color: #808080;
+    color: white;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.25rem;
+    padding: 0.9375rem 7.5625rem;
+    border: none;
+    border-radius: 3.625rem;
+    gap: 0.625rem;
+    cursor: pointer;
+`
+
+export const SaveBtn = styled.button`
+    width: 21.25rem;
+    height: 3.125rem;
+    background-color: #007BFF;
+    color: white;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.25rem;
+    margin-bottom: 1.125rem;
+    padding: 0.9375rem 7.5625rem;
+    border: none;
+    border-radius: 3.625rem;
+    gap: 0.625rem;
+    cursor: pointer;
+`
+
+export const CancelBtn2 = styled.button`
+    width: 100%;
+    height: 1.6875rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    color: #808080;
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.6875rem;
+    padding: 0.9375rem 7.5625rem;
+    border: none;
+    cursor: pointer;
+`

--- a/src/component/measureBtn/MeasureBtn.tsx
+++ b/src/component/measureBtn/MeasureBtn.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { CancelBtn, CancelBtn2, SaveBtn, StartBtn } from './MeasureBtn.styles';
+
+interface MeasureBtnProps {
+  isRecording: boolean;
+  isCompleted: boolean;
+  onStart: () => void;
+  onCancel: () => void;
+  onRegister: () => void;
+}
+
+const MeasureBtn: React.FC<MeasureBtnProps> = ({ isRecording, isCompleted, onStart, onCancel, onRegister }) => {
+  return (
+    <div>
+      {!isRecording && !isCompleted && <StartBtn onClick={onStart}>측정 시작</StartBtn>}
+      {isRecording && !isCompleted && <CancelBtn onClick={onCancel}>측정 취소</CancelBtn>}
+      {isCompleted && (
+        <>
+          <SaveBtn onClick={onRegister}>측정 저장</SaveBtn>
+          <CancelBtn2 onClick={onCancel}>측정 취소</CancelBtn2>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default MeasureBtn;

--- a/src/component/standard/NoiseStandard.styles.ts
+++ b/src/component/standard/NoiseStandard.styles.ts
@@ -10,74 +10,74 @@ export const Background = styled.div`
 `
 
 export const InfoContainer = styled.div`
-    width: 276px;
-    height: 313px;
+    width: 17.25rem;
+    height: 19.5625rem;
     position: absolute;
-    top: 249.5px;
-    left: 50px;
-    border-radius: 15.37px;
+    top: 15.59375rem;
+    left: 3.125rem;
+    border-radius: 0.960625rem;
     background-color: #fff;
     box-shadow: 0px 7.69px 82.21px 0px #2548992B;
-    padding: 16px 15.5px;
+    padding: 1rem 0.96875rem;
 `
 
 export const RowContainer = styled.div`
     width: 100%;
-    margin-bottom: 27px;
+    margin-bottom: 1.6875rem;
     &:last-of-type {
-        margin-bottom: 16px;
+        margin-bottom: 1rem;
     }   
 `
 
 export const RowWrapper = styled.div`
-    width:244px;
-    height: 35px;
-    padding: 4px;
-    gap: 5px;
+    width:15.25rem;
+    height: 2.1875rem;
+    padding: 0.25rem;
+    gap: 0.3125rem;
     background-color:  #E8F0FF;
-    border-radius: 4px;
+    border-radius: 0.25rem;
     display: flex;
     align-items: center;
     justify-content: center;
 `
 
 export const PopUpBtn = styled.button`
-    width: 244px;
-    height: 40px;
+    width: 15.25rem;
+    height: 2.5rem;
     border: none;
-    border-radius: 6.99px;
-    padding: 5.24px 13.97px 5.24px 13.97px;
-    gap: 8.73px;
+    border-radius: 0.436875rem;
+    padding: 0.3275rem 0.873125rem 0.3275rem 0.873125rem;
+    gap: 0.545625rem;
     background-color: #007BFF;
     color: #fff;
     font-family: "Pretendard";
     font-weight: 500;
-    font-size: 16px;
-    line-height: 24px;
+    font-size: 1rem;
+    line-height: 1.5rem;
     text-align: center;
     cursor: pointer;
 `
 
 export const Icon = styled.img`
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
 `
 
 export const DecibelLv = styled.p`
     font-family: "Pretendard";
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: 600;
-    line-height: 27px;
+    line-height: 1.6875rem;
     text-align: left;
 `
 
 export const Description = styled.p`
-    margin-top: 5px;
+    margin-top: 0.3125rem;
     font-family: "Pretendard";
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 400;
-    line-height: 16.8px;
-    letter-spacing: -0.34px;
+    line-height: 1.05rem;
+    letter-spacing: -0.02125rem;
     text-align: left;
     color: #0000008A;
 `

--- a/src/component/time/DateTimeDisplay.tsx
+++ b/src/component/time/DateTimeDisplay.tsx
@@ -16,8 +16,7 @@ const DateTimeDisplay: React.FC<DateTimeDisplayProps> = ({ date }) => {
   const formatTime = (date: Date) => {
     const hours = String(date.getHours()).padStart(2, '0');
     const minutes = String(date.getMinutes()).padStart(2, '0');
-    const seconds = String(date.getSeconds()).padStart(2, '0');
-    return `${hours}:${minutes}:${seconds}`;
+    return `${hours}:${minutes}`;
   };
 
   return (

--- a/src/component/timer/Timer.tsx
+++ b/src/component/timer/Timer.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+interface TimerProps {
+  initialCountdown: number; // 초기 카운트다운 시간
+  isActive: boolean; // 타이머 활성화 여부
+  onComplete: () => void; // 카운트다운 완료 후 호출되는 콜백
+  onReset?: () => void; // 리셋 시 호출되는 콜백
+}
+
+const Timer: React.FC<TimerProps> = ({ initialCountdown, isActive, onComplete, onReset }) => {
+  const [countdown, setCountdown] = useState<number>(initialCountdown);
+  const [elapsedTime, setElapsedTime] = useState<number>(0);
+
+  useEffect(() => {
+    let timerId: NodeJS.Timeout;
+
+    if (isActive) {
+      if (countdown > 0) {
+        timerId = setTimeout(() => setCountdown((prev) => prev - 1), 1000);
+      } else {
+        timerId = setTimeout(() => setElapsedTime((prev) => prev + 1), 1000);
+      }
+    } else {
+      // 타이머가 비활성화되면 초기화
+      setCountdown(initialCountdown);
+      setElapsedTime(0);
+      if (onReset) onReset();
+    }
+
+    return () => clearTimeout(timerId);
+  }, [isActive, countdown, elapsedTime, initialCountdown, onReset]);
+
+  useEffect(() => {
+    if (countdown === 0) {
+      onComplete();
+    }
+  }, [countdown, onComplete]);
+
+  // 타이머 형식 포맷
+  const formatTime = (time: number) =>
+    `${String(Math.floor(time / 60)).padStart(2, '0')}:${String(time % 60).padStart(2, '0')}`;
+
+  const formatElapsedTime = (time: number) =>
+    `+${String(Math.floor(time / 60)).padStart(2, '0')}:${String(time % 60).padStart(2, '0')}`;
+
+  return (
+    <div>
+      {countdown > 0 ? (
+        <p>{formatTime(countdown)}</p>
+      ) : (
+        <p>{formatElapsedTime(elapsedTime)}</p>
+      )}
+    </div>
+  );
+};
+
+export default Timer;

--- a/src/hook/useCoordinateToAddress.tsx
+++ b/src/hook/useCoordinateToAddress.tsx
@@ -4,6 +4,7 @@ const useCoordinateToAddress = (coords: { latitude: number; longitude: number } 
   const [address, setAddress] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+
   useEffect(() => {
     if (!coords) return;
 
@@ -14,10 +15,12 @@ const useCoordinateToAddress = (coords: { latitude: number; longitude: number } 
         const geocoder = new kakao.maps.services.Geocoder();
         const coord = new kakao.maps.LatLng(coords.latitude, coords.longitude);
 
-        geocoder.coord2Address(coord.getLng(), coord.getLat(), (result: any, status: any) => {
+        geocoder.coord2Address(coord.getLng(), coord.getLat(), (result, status) => {
           if (status === kakao.maps.services.Status.OK) {
-            const address = result[0].address.address_name;
-            setAddress(address);
+            const fullAddress = result[0].address.address_name;
+            const addressParts = fullAddress.split(' '); // 공백으로 나누기
+            const trimmedAddress = addressParts.slice(-2).join(' '); // 뒤에서 두 항목만 결합
+            setAddress(trimmedAddress);
           } else {
             setError('주소를 변환하는 데 실패했습니다.');
           }

--- a/src/layout/navBar/NavBar.styles.ts
+++ b/src/layout/navBar/NavBar.styles.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
 export const NavWrapper = styled.div`
-    width: 375px;
-    height: 100px;
-    padding: 10px 46px 40px 47px;
+    width: 23.4375rem;
+    height: 6.25rem;
+    padding: 0.625rem 2.875rem 2.5rem 2.9375rem;
     position: fixed;
     bottom: 0;
     box-shadow: -2px -1px 4px 0px #00000026;
@@ -15,11 +15,11 @@ export const ItemBox = styled.ul`
     align-items: center;
     justify-content: space-between;
     font-weight: 500;
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
     li {
-        width: 52px;
-        height: 50px;
+        width: 3.25rem;
+        height: 3.125rem;
         display: flex;
         text-align: center;
         cursor: pointer;

--- a/src/page/noiseMeasurement/Noise.styles.ts
+++ b/src/page/noiseMeasurement/Noise.styles.ts
@@ -1,3 +1,4 @@
+import { ToastContainer } from "react-toastify";
 import styled from "styled-components";
 
 export const Container = styled.div`
@@ -77,4 +78,22 @@ export const DescriptionWrapper = styled.div`
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: #6D6D6D;
+`
+
+export const StyledToastContainer = styled(ToastContainer)`
+  .Toastify__toast {
+    width: 21.8125rem;
+    height: 2.75rem;
+    padding: 0.625rem;
+    gap: 0.625rem;
+    margin: 0.4375rem 0.8125rem 2.25rem; 
+    background-color: #474747;
+    text-align: center;
+    color: white;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+    opacity: 80%;
+    border-radius: 0.5rem;
+  }
 `

--- a/src/page/noiseMeasurement/Noise.styles.ts
+++ b/src/page/noiseMeasurement/Noise.styles.ts
@@ -52,3 +52,10 @@ export const ChartContainer = styled.div`
     background-color: #F4F4F4;
     border: 2px solid #D7D7D7;
 `
+
+export const InfoHeader = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.0625rem;
+`

--- a/src/page/noiseMeasurement/Noise.styles.ts
+++ b/src/page/noiseMeasurement/Noise.styles.ts
@@ -42,7 +42,7 @@ export const InfoWrapper = styled.div`
     }
 `
 
-export const ChartContainer = styled.div`
+export const ChartContainer = styled.div<{ isRecording: boolean }>`
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -52,8 +52,8 @@ export const ChartContainer = styled.div`
     margin-bottom: 1.125rem;
     padding: 0.75rem 0.75rem 0.8125rem;
     border-radius: 1rem;
-    background-color: #F4F4F4;
-    border: 2px solid #D7D7D7;
+    background-color: ${({ isRecording }) => (isRecording ? '#F4F8FF' : '#F4F4F4')};
+    border: 2px solid ${({ isRecording }) => (isRecording ? '#CFE2FF' : '#D7D7D7')};
 `
 
 export const InfoHeader = styled.div`

--- a/src/page/noiseMeasurement/Noise.styles.ts
+++ b/src/page/noiseMeasurement/Noise.styles.ts
@@ -43,11 +43,14 @@ export const InfoWrapper = styled.div`
 `
 
 export const ChartContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     width: 21.25rem;
     height: 27.75rem;
     margin-right: 0.375rem;
     margin-bottom: 1.125rem;
-    padding: 0.75rem 1rem 0.8125rem;
+    padding: 0.75rem 0.75rem 0.8125rem;
     border-radius: 1rem;
     background-color: #F4F4F4;
     border: 2px solid #D7D7D7;
@@ -57,5 +60,21 @@ export const InfoHeader = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 19.25rem;
     margin-bottom: 1.0625rem;
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
+`
+
+export const DescriptionWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 15.125rem;
+    height: 3.75rem;
+    font-weight: 500;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: #6D6D6D;
 `

--- a/src/page/noiseMeasurement/Noise.tsx
+++ b/src/page/noiseMeasurement/Noise.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Logo from '../../assets/logo/logo.svg';
 import Info from '../../assets/icons/ico_Info.png';
 import { useDispatch } from 'react-redux';
-import { ChartContainer, Container, DescriptionWrapper, Header, InfoHeader, InfoWrapper, LogoWrapper } from './Noise.styles';
+import { ChartContainer, Container, DescriptionWrapper, Header, InfoHeader, InfoWrapper, LogoWrapper, StyledToastContainer } from './Noise.styles';
 import { toggleModal } from '../../store/menu/menuSlice';
 import DateTimeDisplay from '../../component/time/DateTimeDisplay';
 import useCurrentLocation from '../../hook/useCurrentLocation';
@@ -18,6 +18,8 @@ import { DecibelDataPoint } from '../../types/DecibelDataPoint';
 import DecibelChart from '../../component/decibelChart/DecibelChart';
 import Timer from '../../component/timer/Timer';
 import MeasureBtn from '../../component/measureBtn/MeasureBtn';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css'
 
 const Noise = () => {
     const [currentDate, setCurrentDate] = useState(new Date());
@@ -45,7 +47,6 @@ const Noise = () => {
 
     const displayDate = isRecording && fixedDate ? fixedDate : currentDate;
 
-    //const [address, setAddress] = useState<string>('');
     const dispatch = useDispatch();
 
     const handleStart = () => {
@@ -62,6 +63,13 @@ const Noise = () => {
       setMaxDecibel(0); // 최대 데시벨 초기화
       setAverageDecibel(0); // 평균 데시벨 초기화
       setCurrentDecibel(0); // 현재 데시벨 초기화
+      // Toast 메시지 표시
+      toast.info('측정이 취소되었습니다.', {
+          position: "bottom-center",
+          autoClose: 3000,
+          hideProgressBar: true,
+          closeButton: false,
+      });
     };
   
     const handleComplete = () => {
@@ -142,6 +150,7 @@ const Noise = () => {
           onCancel={handleCancel}
           onRegister={handleRegister}
       />
+      <StyledToastContainer />
     </Container>
   );
 };

--- a/src/page/noiseMeasurement/Noise.tsx
+++ b/src/page/noiseMeasurement/Noise.tsx
@@ -11,77 +11,57 @@ import AddressDisplay from '../../component/currentLocate/AddressDisplay';
 import useResetStateOnPath from '../../hook/useResetStateOnPath';
 import { useAppSelector } from '../../hook/redux';
 import { RootState } from '../../store';
+import Marker from '../../component/marker/Marker';
+import { toggleRecording } from '../../store/dateTime/dateTimeSlice';
+import useRecordWithDecibel from '../../hook/useRecordWithDecibel';
 
 const Noise = () => {
     const [currentDate, setCurrentDate] = useState(new Date());
-  
+    const { startMeasuringDecibel, stopMeasuringDecibel, decibel } = useRecordWithDecibel();
+    const [averageDecibel, setAverageDecibel] = useState<number>(0);
+    const [dataPoints, setDataPoints] = useState<number[]>([]);
     const { coords, error: locationError } = useCurrentLocation();
     const { address, error: addressError } = useCoordinateToAddress(coords);
 
-    const { isFixed, fixedDate } = useAppSelector((state: RootState) => state.dateTime);
+    const { isRecording, fixedDate } = useAppSelector((state: RootState) => state.dateTime);
 
     useResetStateOnPath('/measure');
 
     useEffect(() => {
-      if (!isFixed) {
+      if (!isRecording) {
         const intervalId = setInterval(() => {
           setCurrentDate(new Date());
         }, 1000);
         return () => clearInterval(intervalId);
       }
-    }, [isFixed]);
+    }, [isRecording]);
 
-  const displayDate = isFixed && fixedDate ? fixedDate : currentDate;
+    const displayDate = isRecording && fixedDate ? fixedDate : currentDate;
 
-  //const [address, setAddress] = useState<string>('');
-  const dispatch = useDispatch();
+    //const [address, setAddress] = useState<string>('');
+    const dispatch = useDispatch();
 
-  // const fetchAddressFromCoords = () => {
-  //   navigator.geolocation.getCurrentPosition(
-  //     async (position) => {
-  //       const { latitude, longitude } = position.coords;
-  //       console.log('위도:', latitude, '경도:', longitude);
-  //       dispatch(setPosition({x: latitude, y: longitude}));
+    const handleToggleRecording = () => {
+      dispatch(toggleRecording());
+      if (!isRecording) {
+        startMeasuringDecibel();
+      } else {
+        stopMeasuringDecibel();
+      }
+    };
 
-  //       const REST_API_KEY = '83ce629a6d7b809e79dc0b269d5a78c9'; // 카카오 REST API 키
-  //       const url = `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${longitude}&y=${latitude}`;
-
-  //       try {
-  //         const response = await fetch(url, {
-  //           method: 'GET',
-  //           headers: {
-  //             Authorization: `KakaoAK ${REST_API_KEY}`, // 인증 헤더
-  //           },
-  //         });
-
-  //         if (!response.ok) {
-  //           throw new Error(`HTTP error! Status: ${response.status}`);
-  //         }
-
-  //         const data = await response.json();
-  //         if (data && data.documents && data.documents.length > 0) {
-  //           let address = data.documents[0].address_name; // 첫 번째 주소를 가져옴
-  //           console.log('주소:', address);
-  //           address = address.slice(0, 7);
-  //           setAddress(address); // 화면에 주소 표시
-  //         } else {
-  //           console.error('주소 데이터를 찾을 수 없습니다.');
-  //         }
-  //       } catch (error) {
-  //         console.error('API 호출 중 오류 발생:', error);
-  //       }
-  //     },
-  //     (error) => {
-  //       console.error('위치 정보를 가져오는 중 오류 발생:', error);
-  //     }
-  //   );
-  // };
-
-  // useEffect(() => {
-  //   fetchAddressFromCoords(); // 컴포넌트가 마운트될 때 호출
-  // }, []);
-
-
+    useEffect(() => {
+      if (isRecording) {
+        setDataPoints((prev) => [...prev.slice(-49), decibel]); // 최근 50개의 데시벨 데이터 유지
+      }
+    }, [decibel, isRecording]);
+  
+    useEffect(() => {
+      if (dataPoints.length > 0) {
+        const total = dataPoints.reduce((sum, value) => sum + value, 0);
+        setAverageDecibel(total / dataPoints.length);
+      }
+    }, [dataPoints]);
 
   return (
     <Container>
@@ -98,6 +78,7 @@ const Noise = () => {
           <DateTimeDisplay date={displayDate}/>
           <AddressDisplay address={address} locationError={locationError} addressError={addressError} />
         </InfoHeader>
+        <Marker averageDecibel={averageDecibel} isRecording={isRecording} />
         {/* <DecibelChart/> */}
       </ChartContainer>
     </Container>

--- a/src/page/noiseMeasurement/Noise.tsx
+++ b/src/page/noiseMeasurement/Noise.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Logo from '../../assets/logo/logo.svg';
 import Info from '../../assets/icons/ico_Info.png';
 import { useDispatch } from 'react-redux';
-import { ChartContainer, Container, Header, InfoWrapper, LogoWrapper } from './Noise.styles';
+import { ChartContainer, Container, Header, InfoHeader, InfoWrapper, LogoWrapper } from './Noise.styles';
 import { toggleModal } from '../../store/menu/menuSlice';
 import DateTimeDisplay from '../../component/time/DateTimeDisplay';
 import useCurrentLocation from '../../hook/useCurrentLocation';
@@ -94,10 +94,10 @@ const Noise = () => {
         </InfoWrapper>
       </Header>
       <ChartContainer>
-        <div>
+        <InfoHeader>
           <DateTimeDisplay date={displayDate}/>
           <AddressDisplay address={address} locationError={locationError} addressError={addressError} />
-        </div>
+        </InfoHeader>
         {/* <DecibelChart/> */}
       </ChartContainer>
     </Container>

--- a/src/store/dateTime/dateTimeSlice.ts
+++ b/src/store/dateTime/dateTimeSlice.ts
@@ -1,31 +1,31 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 interface TimeState {
-  isFixed: boolean;
+  isRecording: boolean;
   fixedDate: Date | null;
 }
 
 const initialState: TimeState = {
-  isFixed: false,
+  isRecording: false,
   fixedDate: null,
 };
 
 const dateTimeSlice = createSlice({
-  name: 'time',
+  name: 'dateTime',
   initialState,
   reducers: {
-    startMeasurement: (state) => {
-      state.isFixed = true;
+    toggleRecording(state) {
+      state.isRecording = !state.isRecording
+    },
+
+    setFixedDate: (state) => {
       state.fixedDate = new Date();
     },
-    cancelMeasurement: (state) => {
-      state.isFixed = false;
-      state.fixedDate = null;
-    },
+
     resetState: () => initialState,
   },
 });
 
-export const { startMeasurement, cancelMeasurement, resetState } = dateTimeSlice.actions;
+export const { toggleRecording, setFixedDate, resetState } = dateTimeSlice.actions;
 
 export default dateTimeSlice.reducer;

--- a/src/types/DecibelDataPoint.ts
+++ b/src/types/DecibelDataPoint.ts
@@ -1,0 +1,4 @@
+export interface DecibelDataPoint {
+    x: string;
+    y: number;
+}


### PR DESCRIPTION
1. 마커 컴포넌트 분리
- db 크기에 따른 마커 변화

2. Timer 컴포넌트 분리
- 측정 시간 기록 timer 컴포넌트 분리 완료
- 초기 00:15에서 감산되는 형식으로 countdown, 이후 + 00:00에서 증가되는 형식의 timer

3. button 컴포넌트 분리
- 초기 '측정 시작' 버튼 랜더링
- 측정 시작이후 측정 취소 버튼 표시
- 15초 지난 이후 측정 등록과 측정 취소 버튼 표시
- 각 측정 취소 버튼 클릭시 현재db, 평균db, 최대 db 및 그래프 초기화

4. toast 팝업 추가
- 측정 취소 버튼 클릭시 측정이 취소되었다는 toast 팝업 추가
- toastify 라이브러리 사용

5. 현재 위치 주소 불러오기
- geolocation api를 활용하여 현재 위치 좌표값 가져오기
- 카카오맵 library를 활용하여 도로명 주소 받아오기
- 화면에 표시하는 UI 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 소음 측정 기능 강화
  - 측정 상태에 따른 동적 UI 컴포넌트 추가
  - 데시벨 차트 및 마커 기능 도입

- **사용자 경험 개선**
  - 주소 표시 및 위치 아이콘 스타일링
  - 타이머 및 측정 버튼 컴포넌트 추가
  - 반응형 디자인을 위한 스타일 업데이트

- **버그 수정**
  - 주소 및 시간 포맷팅 로직 개선
  - 상태 관리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->